### PR TITLE
Add a wrapper library so that this package can be distributed on Melpa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-CC = gcc
-INC=-I.
-LIB=-lsqlite3
+CC  ?= gcc
+INC ?= -I.
+LIB ?= -lsqlite3
 
 ifeq ($(HOMEBREW), 1)
  INC=-I/usr/local/opt/sqlite3/include
  LIB=-L/usr/local/opt/sqlite3/lib -lsqlite3
 endif
 
-CFLAGS=-g3 -Wall -std=c99 $(INC)
+CFLAGS ?= -g3 -Wall -std=c99 $(INC)
 
-EMACS=/Applications/Emacs.app/Contents/MacOS/Emacs-x86_64-10_14
+EMACS ?= /Applications/Emacs.app/Contents/MacOS/Emacs-x86_64-10_14
 
 # Melpa package
 PKG=sqlite3-api

--- a/sqlite3.el
+++ b/sqlite3.el
@@ -1,0 +1,57 @@
+;;; sqlite3.el --- Direct access to the core SQLite3 API  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2018-2020  Y. N. Lo
+
+;; Author: Y. N. Lo <gordonynlo@yahoo.com>
+;; Homepage: https://github.com/pekingduck/emacs-sqlite3-api
+;; Keywords: comm, data, sql
+
+;; Package-Requires: ((emacs "25.1"))
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; For a full copy of the GNU General Public License
+;; see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; `sqlite3-api' is a dynamic module for GNU Emacs 25+ that provides
+;; direct access to the core SQLite3 C API from Emacs Lisp.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(defvar sqlite3-api-build-command '("make" "all"))
+
+(cl-eval-when (load eval)
+  (unless (require 'sqlite3-api nil t)
+    (if (yes-or-no-p "sqlite3-api module must be build.  Do so now? ")
+        (let ((default-directory (file-name-directory (or load-file-name
+                                                          buffer-file-name))))
+          (with-temp-buffer
+            (unless (zerop (apply #'call-process
+                                  (car sqlite3-api-build-command) nil t t
+                                  (cdr sqlite3-api-build-command)))
+              (error "Failed to compile module using: %s: %s"
+                     (mapconcat #'identity sqlite3-api-build-command " ")
+                     (buffer-substring-no-properties
+                      (point-min)
+                      (point-max))))))
+      (user-error "Abort"))))
+
+(provide 'sqlite3)
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+;;; sqlite3.el ends here


### PR DESCRIPTION
I saw that the Makefile contains support for building a `package.el`-compatible package named `sqlite3-api` but think this should be available from Melpa so that third-party packages can actually start depending on this.

Melpa gets a packages metadata from the elisp library that matches the name of the package. This repository contained no such library. Because the name of the dynamic module is `sqlite3-api.so`, we cannot use `sqlite3-api.el`. Modules and libraries live in the same "namespace", which makes it possible to `require` both, so they cannot have conflicting names.

I went with `sqlite3.el`, which means that the package ends up being named `sqlite3`, which I personally think is a better name than `sqlite3-api` anyway.  But if you don't want that, then you would have to rename `sqlite3.el` to `sqlite3-api.el` and `sqlite3-api.c` to something like e.g. `sqlite3-api-module.c`.

If you merge this, then I can take care of adding the module to Melpa (though you might have to take care of the review feedback). For now I have used this recipe for local testing:

``` emacs-lisp
(sqlite3
 ;; :fetcher github
 ;; :repo "pekingduck/emacs-sqlite3-api"
 ;; :repo "tarsiiformes/emacs-sqlite3-api"
 :fetcher git :url "/home/jonas/.emacs.d/lib/sqlite3"
 :branch "melpa-alt"
 :files (:defaults
	 "Makefile"
	 "consts.c"
	 "emacs-module.h"
	 "sqlite3-api.c"))
```

----

The wrapper library takes care of building the module if necessary (unlike your old attempt in the `dummy-el` branch).

----

Please note that this is currently used the `melpa-alt`, which does not branch of the latest `master` but from the commit before 781f915cd4ebbb5941b290aed7109c767e93f5d2.  That commit breaks building for me, resulting in these errors:

```
$ make clean all
rm -rf *.so *.o *.tar sqlite3-api-0.13
gcc -g3 -Wall -std=c99 -I. -fPIC -c sqlite3-api.c
In file included from sqlite3-api.c:1096:
consts.c: In function ‘emacs_module_init’:
consts.c:127:77: error: ‘SQLITE_OPEN_FILEPROTECTION_COMPLETE’ undeclared (first use in this function); did you mean ‘SQLITE_OPEN_DELETEONCLOSE’?
 defconst(env, "sqlite-open-fileprotection-complete", env->make_integer(env, SQLITE_OPEN_FILEPROTECTION_COMPLETE));
                                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                             SQLITE_OPEN_DELETEONCLOSE
consts.c:127:77: note: each undeclared identifier is reported only once for each function it appears in
consts.c:128:87: error: ‘SQLITE_OPEN_FILEPROTECTION_COMPLETEUNLESSOPEN’ undeclared (first use in this function)
 defconst(env, "sqlite-open-fileprotection-completeunlessopen", env->make_integer(env, SQLITE_OPEN_FILEPROTECTION_COMPLETEUNLESSOPEN));
                                                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
consts.c:129:105: error: ‘SQLITE_OPEN_FILEPROTECTION_COMPLETEUNTILFIRSTUSERAUTHENTICATION’ undeclared (first use in this function)
 defconst(env, "sqlite-open-fileprotection-completeuntilfirstuserauthentication", env->make_integer(env, SQLITE_OPEN_FILEPROTECTION_COMPLETEUNTILFIRSTUSERAUTHENTICATION));
                                                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
consts.c:130:73: error: ‘SQLITE_OPEN_FILEPROTECTION_NONE’ undeclared (first use in this function); did you mean ‘SQLITE_OPEN_DELETEONCLOSE’?
 defconst(env, "sqlite-open-fileprotection-none", env->make_integer(env, SQLITE_OPEN_FILEPROTECTION_NONE));
                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                         SQLITE_OPEN_DELETEONCLOSE
consts.c:131:73: error: ‘SQLITE_OPEN_FILEPROTECTION_MASK’ undeclared (first use in this function); did you mean ‘SQLITE_OPEN_DELETEONCLOSE’?
 defconst(env, "sqlite-open-fileprotection-mask", env->make_integer(env, SQLITE_OPEN_FILEPROTECTION_MASK));
                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                         SQLITE_OPEN_DELETEONCLOSE
consts.c:240:73: error: ‘SQLITE_DBCONFIG_WRITABLE_SCHEMA’ undeclared (first use in this function); did you mean ‘SQLITE_DBCONFIG_ENABLE_FKEY’?
 defconst(env, "sqlite-dbconfig-writable-schema", env->make_integer(env, SQLITE_DBCONFIG_WRITABLE_SCHEMA));
                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                         SQLITE_DBCONFIG_ENABLE_FKEY
make: *** [Makefile:55: sqlite3-api.o] Error 1
```