### PR TITLE
Load the sqlite3-api module after compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    # Run the tests for all OSs and EMACS_VERSIONs.
+    runs-on: ${{matrix.os}}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        emacs_version: ['28.2', '29.1']
+
+    steps:
+    - name: Setup dev env (MS-Windows)
+      uses: msys2/setup-msys2@v2
+      if: startsWith (matrix.os, 'windows')
+      with:
+        msystem: MINGW64
+        location: D:\
+        pacboy: >-
+          gcc:p sqlite3:p
+
+    - name: Set up Emacs
+      if: "!startsWith (matrix.os, 'windows')"
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{matrix.emacs_version}}
+
+    - name: Set up Emacs (MS-Windows)
+      if: startsWith (matrix.os, 'windows')
+      uses: jcs090218/setup-emacs-windows@master
+      with:
+        version: ${{matrix.emacs_version}}
+
+    - name: Install Eldev
+      if: "!startsWith (matrix.os, 'windows')"
+      run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
+
+    - name: Install Eldev (MS-Windows)
+      if: startsWith (matrix.os, 'windows')
+      run: |
+        # Remove expired DST Root CA X3 certificate. Workaround
+        # for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51038
+        # bug on Emacs 27.2.
+        gci cert:\LocalMachine\Root\DAC9024F54D8F6DF94935FB1732638CA6AD77C13
+        gci cert:\LocalMachine\Root\DAC9024F54D8F6DF94935FB1732638CA6AD77C13 | Remove-Item
+
+        curl.exe -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev.bat | cmd /Q
+
+    - name: Check out the source code
+      uses: actions/checkout@v3
+
+    - name: Test
+      if: "!startsWith (matrix.os, 'windows')"
+      env:
+        # purcell/setup-emacs releases are built with nix and as such
+        # we need to build the api with nix for binary compatibility.
+        SQLITE3_API_BUILD_COMMAND: "nix-shell -p sqlite.dev --run \"make all\""
+      run: |
+        eldev -p -dtTC test
+
+    - name: Test (MS-Windows)
+      if: startsWith (matrix.os, 'windows')
+      run: |
+        # Update PATH to include first to the new msys2 dev
+        # environment.
+        $env:Path = "D:\msys64\mingw64\bin;" + $env:Path
+        #
+        eldev -p -dtTC test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 *.o
 *.so
+*.dll
 **/.DS_Store
 sqlite3-napi-module-with-create-function.c
 xxx.el
 **/sqlite3-api-*
-**/sqlite3-*
+
+*~
+**/sqlite3-*# Added automatically by `eldev init'.
+/.eldev
+/Eldev-local

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,6 @@
+; -*- mode: emacs-lisp; lexical-binding: t -*-
+
+(setf eldev-project-source-dirs ".")
+(setf eldev-files-to-package
+      `(:or ,eldev-files-to-package
+                  '("./Makefile" "./consts.c" "./emacs-module.h" "./sqlite3-api.c")))

--- a/README.org
+++ b/README.org
@@ -94,9 +94,6 @@ compilation of the dynamic module:
 sqlite3-api module must be built.  Do so now?
 #+END_SRC
 
-After the module is successfully compiled, you should ~(unload-feature
-'sqlite3)~ and then ~(require sqlite3)~ to reload properly.
-
 *** Elpa
 #+BEGIN_SRC sh :eval no :exports code
 $ git co https://github.com/pekingduck/emacs-sqlite3-api

--- a/README.org
+++ b/README.org
@@ -49,6 +49,7 @@
     - [[#manual-installation][Manual Installation]]
     - [[#removal][Removal]]
     - [[#note-on-package-update][Note on Package Update]]
+  - [[#testing][Testing]]
   - [[#api][API]]
     - [[#sqlite3-open][sqlite3-open]]
     - [[#sqlite3-close][sqlite3-close]]
@@ -67,7 +68,7 @@
     - [[#sqlite3-fetch-alist][sqlite3-fetch-alist]]
   - [[#transaction-support][Transaction Support]]
   - [[#error-handling][Error Handling]]
-  - [[#a-note-on-garbage-collection][A Note on Garbage Collection]]
+  - [[#note-on-garbage-collection][Note on Garbage Collection]]
   - [[#known-problems][Known Problems]]
   - [[#license][License]]
   - [[#contributors][Contributors]]
@@ -82,7 +83,8 @@
 - SQLite3 v3.16.0 or above. Older versions might work but I have not personally tested those.
 - A C99 compiler
 
-It's been tested on macOS (Catalina) and CentOS 7.
+It's been tested on macOS (Catalina), CentOS 7 and MS-Windows 11.
+
 ** Installation & Removal
 *** Melpa
 The package is available on [[https://melpa.org/#/sqlite3][Melpa]] (thanks to @tarsius).
@@ -93,6 +95,8 @@ compilation of the dynamic module:
 #+BEGIN_SRC text :eval no :exports code
 sqlite3-api module must be built.  Do so now?
 #+END_SRC
+
+The module is built using the `make all` command by default. To customize the build process, you can override this behavior by setting the `SQLITE3_API_BUILD_COMMAND` environment variable.
 
 *** Elpa
 #+BEGIN_SRC sh :eval no :exports code
@@ -141,6 +145,18 @@ does support unloading of dynamic modules. To unload ~sqlite3~ properly:
 (unload-feature 'sqlite3-api)
 #+END_SRC
 
+** Testing
+
+The tests can be run with the [[https://github.com/emacs-eldev/eldev][Eldev]] build tool
+
+#+BEGIN_SRC sh :eval no :exports code
+  # from source
+  eldev test
+  # or as a compiled package
+  eldev -p test
+#+END_SRC
+
+See [[https://emacs-eldev.github.io/eldev/][Eldev documentation]] for more information.
 
 ** API
 To load the package, put the following in your ~.emacs~:

--- a/sqlite3.el
+++ b/sqlite3.el
@@ -32,7 +32,12 @@
 
 (require 'cl-lib)
 
-(defvar sqlite3-api-build-command '("make" "all"))
+(defvar sqlite3-api-build-command (or (getenv "SQLITE3_API_BUILD_COMMAND")
+                                      "make all")
+  "String containing the build command for the sqlite3-api module.
+
+It defaults to \"make all\".  It can be overriden by
+setting the SQLITE3_API_BUILD_COMMAND environment variable.")
 
 (cl-eval-when (load eval)
   (unless (require 'sqlite3-api nil t)
@@ -40,13 +45,12 @@
             (yes-or-no-p "sqlite3-api module must be built.  Do so now? "))
         (let ((default-directory (file-name-directory (or load-file-name
                                                           buffer-file-name))))
-          (message "Building sqlite3-api module...")
+          (message "Building sqlite3-api module with %S" sqlite3-api-build-command)
           (with-temp-buffer
-            (unless (zerop (apply #'call-process
-                                  (car sqlite3-api-build-command) nil t t
-                                  (cdr sqlite3-api-build-command)))
+            (unless (zerop (call-process-shell-command
+                            sqlite3-api-build-command nil t t))
               (error "Failed to compile module using: %s: %s"
-                     (mapconcat #'identity sqlite3-api-build-command " ")
+                     sqlite3-api-build-command
                      (buffer-substring-no-properties
                       (point-min)
                       (point-max)))))

--- a/sqlite3.el
+++ b/sqlite3.el
@@ -40,6 +40,7 @@
             (yes-or-no-p "sqlite3-api module must be built.  Do so now? "))
         (let ((default-directory (file-name-directory (or load-file-name
                                                           buffer-file-name))))
+          (message "Building sqlite3-api module...")
           (with-temp-buffer
             (unless (zerop (apply #'call-process
                                   (car sqlite3-api-build-command) nil t t
@@ -48,7 +49,9 @@
                      (mapconcat #'identity sqlite3-api-build-command " ")
                      (buffer-substring-no-properties
                       (point-min)
-                      (point-max))))))
+                      (point-max)))))
+          (message "Loading sqlite3-api module...")
+          (require 'sqlite3-api))
       (user-error "Abort"))))
 
 (provide 'sqlite3)

--- a/tests/consts.el
+++ b/tests/consts.el
@@ -14,18 +14,19 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;
 
-(require 'sqlite3-api)
+(require 'sqlite3)
 (require 'cl)
 
 
 (ert-deftest sqlite3-test-consts ()
   (message "Tests:consts")
-  (progn
+  (let ((vl (version-to-list sqlite-version)))
     ;; should pass the test
     (should (boundp 'sqlite-ok))
-    ;; older versions (3.28) doesn't have it defined
-    (should-not (boundp 'sqlite-ioerr-data))
-    ))
+    (if (version-list-<= vl '(3 28))
+        ;; older versions (3.28) doesn't have it defined
+        (should-not (boundp 'sqlite-ioerr-data))
+      (should (boundp 'sqlite-ioerr-data)))))
 
 (sqlite3-set-log-level 3)
 (ert "^sqlite3-test")


### PR DESCRIPTION
Hi,

could you please consider patch to load the `sqlite3-api` module after compilation so that it is immediately available to the environment. It addresses #10.

The main change is in the first commit in `sqlite3.el` where the `sqlite3-api` is `required` just after successful compilation. The documentation is also updated to reflect that it is not needed any more to reload the package. It is not obvious to me why this was omitted in the first place (I might be missing something).

I took the liberty of creating a GitHub action with the second commit  to run the existing tests in CI across all main architectures (MS-Windows, macos and ubuntu) so as to confirm everything is working as expected, in the hope that this will be generally useful. I can split it to a separate PR if required.

The CI change includes:
1. The use of https://github.com/emacs-eldev/eldev build tool to simplify testing as a package (it compiles and install the package locally for testing). It uses the `Eldev` file to configure which files to package.
2. The customization of the module build command via the `SQLITE3_API_BUILD_COMMAND` environment variable so that it can be build with `nix` in CI. This is required because the version of Emacs installed is built with nix and the module needs to be compatible with that.
3. An update in `tests/consts.el` to test the availability of `sqlite-ioerr-data` based on the SQLite version the module was build with.

Eldev is a very capable and simple to use build tool to manage the development of elisp packages. We are only use it here to simplify the testing ([more info](https://emacs-eldev.github.io/eldev/)).

Thanks

