### PR TITLE
fix(Makefile): Make the paths to emacs and sqlite more generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,14 @@ INC ?= -I.
 LIB ?= -lsqlite3
 
 ifeq ($(HOMEBREW), 1)
- INC=-I/usr/local/opt/sqlite3/include
- LIB=-L/usr/local/opt/sqlite3/lib -lsqlite3
-endif
-
-ifeq ($(LINUXBREW), 1)
- PREFIX=/home/linuxbrew/.linuxbrew/opt
+ PREFIX=$(shell brew --prefix sqlite)
  INC=-I$(PREFIX)/include
  LIB=-L$(PREFIX)/lib -lsqlite3
 endif
 
 CFLAGS ?= -g3 -Wall -std=c99 $(INC)
 
-EMACS ?= /Applications/Emacs.app/Contents/MacOS/Emacs-x86_64-10_14
+EMACS ?= $(shell which emacs)
 
 UNAME_O=$(shell uname -o)
 ifeq ($(UNAME_O),Cygwin)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ ifeq ($(HOMEBREW), 1)
  LIB=-L/usr/local/opt/sqlite3/lib -lsqlite3
 endif
 
+ifeq ($(LINUXBREW), 1)
+ PREFIX=/home/linuxbrew/.linuxbrew/opt
+ INC=-I$(PREFIX)/include
+ LIB=-L$(PREFIX)/lib -lsqlite3
+endif
+
 CFLAGS ?= -g3 -Wall -std=c99 $(INC)
 
 EMACS ?= /Applications/Emacs.app/Contents/MacOS/Emacs-x86_64-10_14


### PR DESCRIPTION
Sorry for the delay, I was out of town at a wedding with no computer, aside from my phone.

This PR addresses part 1 of #13 to have the makefile execute the `brew --prefix sqlite` command to find the include and lib paths for sqlite when the `HOMEBREW=1` environment variable is set when `make` is executed.

Additionally, if emacs were to be installed in a non standard location, `which emacs` on a UNIX system (and likely cygwin in Windows) will resolve to the user's PATH.